### PR TITLE
Clean index before git reset and when clearing depot

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -154,7 +154,10 @@ class DepotOperations(BaseDepotOps):
                     else:
                         os.remove(dirty_file_path)
         else:
-            repository.checkout_head(pygit2.GIT_CHECKOUT_FORCE)
+            repository.reset(repository.head.target, pygit2.GIT_RESET_HARD)
+            repository.checkout_head(
+                    pygit2.GIT_CHECKOUT_FORCE |
+                    pygit2.GIT_CHECKOUT_REMOVE_UNTRACKED)
 
     def clear_depot(self, path):
         """

--- a/repoman/git/repository.py
+++ b/repoman/git/repository.py
@@ -602,6 +602,8 @@ class Repository(BaseRepo):
         http://stackoverflow.com/questions/22620393/git-remove-local-changes
         """
         try:
+            # Clean index to avoid unmerged files
+            sh.git('read-tree', '--empty', _cwd=self.path)
             sh.git('reset', '--hard', _cwd=self.path)
             sh.git('clean', '-f', _cwd=self.path)
         except Exception:


### PR DESCRIPTION
git index is cleaned on clear operations.

`git read-tree empty` is used before `git reset` as `git reset` can have nasty behaviours with unmerged files in the index.

`reset` is used with `pygit2` as it implicitelly cleans the index.

I tried to do a test reproducing the issue we had in Tuenti, but I couldn't, in any case this code is able to recover the working copies we broke.
