### PR TITLE
Fixing Git commit, as far as it should work as git commit -a.

### DIFF
--- a/docker/files/run.sh
+++ b/docker/files/run.sh
@@ -8,10 +8,4 @@ fi
 cd /source
 pip install -r requirements.txt --src /tmp/pip-src
 
-# Workaround for needed hg configuration
-cat > $HOME/.hgrc << EOF
-[ui]
-username = test
-EOF
-
 py.test "$@"

--- a/repoman/git/repository.py
+++ b/repoman/git/repository.py
@@ -530,6 +530,12 @@ class Repository(BaseRepo):
             logger.debug("Nothing to commit, repository clean")
             return None
 
+        # if the working copy is dirty, adds all modified files (git commit -a)
+        if status:
+            for filename, filestatus in status.items():
+                if filestatus & pygit2.GIT_STATUS_WT_MODIFIED:
+                    self._repository.index.add(filename)
+
         # Write the index to disk
         oid = self._repository.index.write_tree()
 

--- a/repoman/hg/repository.py
+++ b/repoman/hg/repository.py
@@ -448,10 +448,19 @@ class Repository(BaseRepo):
                allow_empty=False):
         """ Inherited method
         :func:`~repoman.repository.Repository.commit`
+
+        Advise: allow_empty not commit on non-changed working copy,
+        but it won't raise an error.
         """
         def branch_exists():
             return any(repo.branch() == b[0] for b in repo.branches())
-        if not repo.status() and branch_exists():
+        def has_modifications():
+            return repo.status(added=True,
+                               modified=True,
+                               removed=True,
+                               deleted=False,
+            )
+        if not allow_empty and not has_modifications() and branch_exists():
             logger.info("Nothing to commit, repository clean")
             return None
         repo.commit(

--- a/repoman/repository.py
+++ b/repoman/repository.py
@@ -368,7 +368,8 @@ class Repository(object):
     def commit(self, message, custom_parent=None, allow_empty=False):
         """
         Commits changes in current working copy. This will implement a
-        git commit -a behaviour.
+        'hg commit' behaviour, adding all modified files if necessary and
+        ignoring removed files.
 
         :param message: commit message
         :type message: string

--- a/tests/test_clonemanager.py
+++ b/tests/test_clonemanager.py
@@ -18,6 +18,7 @@
 import tempfile
 import shutil
 import os
+import logging
 try:
     import unittest2 as unittest
 except ImportError:
@@ -29,6 +30,7 @@ from repoman.roster import Clone
 FIXTURE_PATH = 'fixtures'
 SELF_DIRECTORY_PATH = os.path.dirname(__file__)
 
+logging.basicConfig()
 
 class AbstractTestDepotManager(object):
     REPO_KIND = None


### PR DESCRIPTION
In order to maintain the same behavior between mercurial and git, the commit should do a "git commit -a" but it was not.

I thought in implement it as optional, but mercurial does not have an index, so I've had to implement one for it and I think it is too much work right now.

So, now it works as documentation said it should.
