### PR TITLE
Change how to set the data of the exception MergeConflictError

### DIFF
--- a/repoman/hg/repository.py
+++ b/repoman/hg/repository.py
@@ -387,7 +387,7 @@ class Repository(BaseRepo):
                     (local_branch.name, other_branch_name, other_rev.hash)
                 if "merging" in str(e) and "failed" in str(e):
                     logger.exception("Merging failed with conflicts:")
-                    raise MergeConflictError(e[2])
+                    raise MergeConflictError(e.out)
                 elif self.MERGING_WITH_ANCESTOR_LITERAL in e.err:
                     # Ugly way to detect this error, but the e.ret is not
                     # correct


### PR DESCRIPTION
Change how to set the data of the exception MergeConflictError (using out field).

When MergeConflictError is raised, it was created using e[2] but it was producing an error due to this is the third  parameter in the command line.

This pull request is to change it by e.out, to set as the parameter of the exception the standard output of the command.
