### PR TITLE
Hg reporting the merge errors.

### DIFF
--- a/repoman/hg/repository.py
+++ b/repoman/hg/repository.py
@@ -387,7 +387,7 @@ class Repository(BaseRepo):
                     (local_branch.name, other_branch_name, other_rev.hash)
                 if "merging" in str(e) and "failed" in str(e):
                     logger.exception("Merging failed with conflicts:")
-                    raise MergeConflictError(e[2])
+                    raise MergeConflictError(e.err)
                 elif self.MERGING_WITH_ANCESTOR_LITERAL in e.err:
                     # Ugly way to detect this error, but the e.ret is not
                     # correct


### PR DESCRIPTION
The same way Git merge errors report the errors, mercurial should report the errors, not the changeset