### PR TITLE
grab_changesets method in git repository changed to use shell commands

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -63,8 +63,9 @@ class DepotOperations(BaseDepotOps):
                 logger.debug('GIT Done grabbing changesets from github')
             else:
                 previous_branch = git_repo.head.shorthand
+                subprocess.call('git reset --hard', cwd=path, shell=True)
                 subprocess.call('git checkout --detach', cwd=path, shell=True)
-                subprocess.call('git fetch', cwd=path, shell=True)
+                subprocess.call('git fetch origin', cwd=path, shell=True)
                 subprocess.call('git checkout %s' % previous_branch, cwd=path,
                                 shell=True)
                 logger.debug('GIT Done grabbing changesets')

--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -67,7 +67,7 @@ class DepotOperations(BaseDepotOps):
                 subprocess.call('git fetch', cwd=path, shell=True)
                 subprocess.call('git checkout %s' % previous_branch, cwd=path,
                                 shell=True)
-                logger.debug('GIT Done grabbing changesets from github')
+                logger.debug('GIT Done grabbing changesets')
         except Exception:
             logger.exception("Error running git fetch")
             return False


### PR DESCRIPTION
There are some operations of fetch that are failing due to some files are untracked. 
As example:

```Exception: 

  RAN: '/usr/bin/git checkout a4ad7777e66c39abe6bb237ab647a9370e8eb15f'

  STDOUT:

  STDERR:
error: The following untracked working tree files would be overwritten by checkout:
	app/src/androidTest/java/com/tuenti/messenger/test/core/espresso/matcher/ChatMessageMatcher.java
	app/src/main/java/com/tuenti/messenger/conversations/conversationscreen/ioc/GetUIChatMessagesInteractor.java
	app/src/main/java/com/tuenti/messenger/conversations/conversationscreen/ioc/GetUIChatMessagesProvider.java
	app/src/main/java/com/tuenti/messenger/conversations/conversationscreen/ioc/... (3362 more, please see e.stderr)
```

Checking `fetch` method in git/depot_operations.py , origin.fetch() method from pygit updates the current working copy from changeset A to the origin HEAD. However, it also leaves all the files modified between A and HEAD in the git stage. Example:

```
user@localhost:~/.repo/workspacean_aHy$ git log -n 1 --format="%H"
21d1fa3ffa12201b2aafc8888759d62644d126c6 # <-- current changeset in working copy
user@localhost:~/.repo/workspacean_aHy$ git status
# On branch integration
nothing to commit (working directory clean)
user@localhost:~/.repo/workspacean_aHy$  # after origin.fetch()
user@localhost:~/.repo/workspacean_aHy$ git log -n 1 --oneline
570c52c326fb13b5b6d2a43144a7da53d79016b8 #  <--- changeset fetched from origin
user@localhost:~/.repo/workspacean_aHy$ git status
# On branch integration
# Changes to be committed:
#   (use "git reset HEAD <file>..." to unstage)
#
#	modified:   .ci.yml
#	modified:   Makefile
#	modified:   app/app_version.properties
#	modified:   app/build.gradle
....
```

With those changes, when doing an `update()` operation using repoman, it failed due to some of those files in stage cannot be clean since in origin do not exist anymore. The clean method does these steps to ensure that working copy is not dirty:
```
git read-tree --empty
git reset --hard
git clean -d -fx ""
```

In this PR, grab_changesets method has been modified in order to use shell commads as well as to ensure no files remain in the stage after fetch operation.