### PR TITLE
Fix grab changesets if detached or dirty

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -85,7 +85,9 @@ class DepotOperations(BaseDepotOps):
                         path, parent))
             bare = not parent
 
-            pygit2.init_repository(path, bare)
+            pygit2.clone_repository(source if bare else parent.path,
+                                    path,
+                                    bare)
 
             result = self.get_depot_from_path(path, parent)
             logger.info('Done initializing Depot.')

--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -58,7 +58,7 @@ class DepotOperations(BaseDepotOps):
         try:
             if git_repo.is_bare:
                 subprocess.call('git fetch %s' % url, cwd=path, shell=True)
-                # this second fetch is needed to set HEAD
+                # This second fetch is needed to set HEAD
                 subprocess.call('git fetch', cwd=path, shell=True)
                 logger.debug('GIT Done grabbing changesets from github')
             else:


### PR DESCRIPTION
After changing how the new changesets are fetched, there are some issues in two different scenarios:
 - a new workspace has been created and it has no reference where to `git reset --hard` or it is detached
 - a previous workspace has left the working copy dirty

In this PR, there are two main changes:
 - New workspaces are created by using pygit clone function. In this way, they will have a valid reference (default remote branch) after cloning.
 - Grab changesets function has been modified in order to clean the working copy:
 -- Fetch from origin and force a checkout to a branch, avoiding files modified
 -- Clean all untracked files (git clean -d -fx "")