### PR TITLE
Fix push to unqualified destination

### DIFF
--- a/tests/test_gitrepository.py
+++ b/tests/test_gitrepository.py
@@ -351,6 +351,37 @@ class TestGitRepository(unittest.TestCase):
         changesets2 = list(git2('log', pretty='oneline', _iter=True))
         self.assertEquals(len(changesets1), len(changesets2))
 
+    def test_push_to_unqualified_destination(self):
+        git1 = GitCmd(self.main_repo_bare)
+        git2 = GitCmd(self.cloned_from_repo)
+
+        repo2 = Repository(self.cloned_from_repo)
+        cs = repo2.commit('A commit', allow_empty=True)
+
+        # Pushing a revision to a reference name that doesn't exist is
+        # considered a push to an unqualified destination
+        repo2.push(self.main_repo, self.main_repo_bare, rev=cs.hash, ref_name='unqualified')
+
+        changesets1 = list(git1('log', 'unqualified', pretty='oneline', _iter=True))
+        changesets2 = list(git2('log', cs.hash, pretty='oneline', _iter=True))
+        self.assertEquals(changesets1, changesets2)
+
+    def test_push_tag_to_unqualified_destination(self):
+        git1 = GitCmd(self.main_repo_bare)
+        git2 = GitCmd(self.cloned_from_repo)
+
+        repo2 = Repository(self.cloned_from_repo)
+        cs = repo2.commit('A commit', allow_empty=True)
+        repo2.tag('unqualified', revision=cs.hash)
+
+        # Pushing a revision to a reference name that doesn't exist is
+        # considered a push to an unqualified destination
+        repo2.push(self.main_repo, self.main_repo_bare, rev=cs.hash, ref_name='unqualified')
+
+        changesets1 = list(git1('log', 'unqualified', pretty='oneline', _iter=True))
+        changesets2 = list(git2('log', 'unqualified', pretty='oneline', _iter=True))
+        self.assertEquals(changesets1, changesets2)
+
     def test_get_branch(self):
         repo = Repository(self.cloned_from_repo)
         branch = repo.get_branch('newbranch')


### PR DESCRIPTION
When pushing a revision to a not existing reference git cannot know what the reference is and it fails, for example the test added in this PR fails with:
```
E           error: unable to push to unqualified destination: notexisting
E           The destination refspec neither matches an existing ref on the remote nor
E           begins with refs/, and we are unable to guess a prefix based on the source ref.
E           error: failed to push some refs to '/tmp/tmpWe7qX3/main_bare'
```

The fix here assumes that we want to push to a new branch (we could want to push to a new tag).

Alternativelly we could force the client to be explicit about the kind of reference it wants to create (i.e. when pushing it should use the parameter with `ref/whatever` preffix, e.g: `repo.push(rev=fe1464e022f28c, ref_name='refs/heads/branch')` or `repo.push(rev=fe1464e022f28c, ref_name='refs/tags/branch')`, but this would require changes in clients, and wouldn't be scm-independent.