### PR TITLE
Fix git check for changeset availability

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -45,9 +45,10 @@ class DepotOperations(BaseDepotOps):
         missing = []
         for c in changesets:
             try:
-                sh.git('rev-parse', c, '--', _cwd=path)
+                sh.git('branch', '--contains', c, _cwd=path)
             except sh.ErrorReturnCode:
                 missing.append(c)
+
         return missing
 
     def grab_changesets(self, path, url, changesets):

--- a/tests/test_gitdepotoperations.py
+++ b/tests/test_gitdepotoperations.py
@@ -95,6 +95,8 @@ class TestGitDepotOperations(unittest.TestCase):
         # index 0000000..e69de29
         #
 
+        missing_changeset = '52109e71fd7f16cb366acfcbb140d6d7f2fc50c8'
+
         self.add_content_to_repo(
             os.path.join(FIXTURE_PATH, 'fixture-1.git.bundle'), 'repo1')
         dcvs = DepotOperations()
@@ -108,17 +110,26 @@ class TestGitDepotOperations(unittest.TestCase):
 
         # It is not there
         self.assertEquals(
-            ['deadbeef'],
+            [missing_changeset],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
-                ['deadbeef']))
+                [missing_changeset]))
+
+        # Missing branches and changesets
+        self.assertEquals(
+            ['missing_branch', missing_changeset, 'deadbeef'],
+            dcvs.check_changeset_availability(
+                os.path.join(self.environment_path, 'repo1'),
+                ['missing_branch', missing_changeset, 'deadbeef']))
+
 
         # Multiple changesets
         self.assertEquals(
-            ['deadbeef'],
+            [missing_changeset],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
-                ['deadbeef', '52109e71fd7f16cb366acfcbb140d6d7f2fc50c9']))
+                [missing_changeset,
+                 '52109e71fd7f16cb366acfcbb140d6d7f2fc50c9']))
 
         # All changesets
         self.assertEquals(


### PR DESCRIPTION
As proposed by @mrodm , use `branch --contains` instead of `rev-parse` to check for changesets availability, `rev-parse` only checks that the changeset is a valid sha-1, not if the changeset really exists in the repository.

I have also extended the tests to use full sha-1s too so problems under this case are covered.