### PR TITLE
Fix git log call tty

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -73,7 +73,7 @@ class DepotOperations(BaseDepotOps):
 
         for c in changesets:
             try:
-                sh.git('log', '-1', c, _cwd=path)
+                sh.git('log', '-1', c, _cwd=path, _tty_out=False)
             except sh.ErrorReturnCode:
                 return False
         return True

--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -74,7 +74,8 @@ class DepotOperations(BaseDepotOps):
         for c in changesets:
             try:
                 sh.git('log', '-1', c, _cwd=path, _tty_out=False)
-            except sh.ErrorReturnCode:
+            except sh.ErrorReturnCode as e:
+                logger.debug('Error checking changeset %s: %s', c, e)
                 return False
         return True
 
@@ -84,7 +85,7 @@ class DepotOperations(BaseDepotOps):
         """
         logger.info('Initializing Depot %s with parent %s' % (
                     path, parent))
- 
+
         sh.git('init', path, bare=not parent)
 
         logger.info('Done initializing depot')


### PR DESCRIPTION
This PR adds the parameter `_tty_out=False` to avoid the errors in `git log` described here: https://amoffat.github.io/sh/sections/faq.html#why-is-tty-out-true-the-default 

The error in this method was the following one:
```
   RAN: /usr/bin/git log -1 integration
 
   STDOUT:
 -  (press RETURN)
 
   STDERR:
 WARNING: terminal is not fully functional
```