### PR TITLE
LIFE-890 add push notes to git repository

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ generate your own packages, usual tools can be used for that, e.g:
 Requirements
 ------------
 
-Repoman should play well with any Linux distribution with Python > 2.6,
+Repoman should play well with any Linux distribution with Python >= 3.4,
 it's daily used in Debian, and has been also tested in Ubuntu and
 Fedora.
 

--- a/repoman/git/repository.py
+++ b/repoman/git/repository.py
@@ -355,9 +355,6 @@ class Repository(BaseRepo):
                   f=force)
         return self.tip()
 
-    def push_notes(self, dest):
-        self._git("push", dest, "refs/notes/*")
-
     def _merge(self, local_branch=None, other_rev=None,
                other_branch_name=None, dry_run=False, strategy=GitMerge):
         merge = strategy(self, local_branch, other_rev, other_branch_name)

--- a/repoman/git/repository.py
+++ b/repoman/git/repository.py
@@ -335,29 +335,24 @@ class Repository(BaseRepo):
         """Inherited method
         :func:`~repoman.repository.Repository.push`
         """
-        if rev == None and ref_name == None:
+        if rev is None and ref_name is None:
             # Push everything
             refspec = "refs/*:refs/*"
-        elif rev == None:
+        elif rev is None:
             refspec = "%s:%s" % (ref_name, ref_name)
-        elif ref_name == None:
-            raise RepositoryError("When pushing, revision specified but not reference name")
+        elif ref_name is None:
+            raise RepositoryError(
+                "When pushing, revision specified but not reference name")
         else:
-            remote_refs = list(
-                self._git("ls-remote", "--tags", "--heads",
-                          dest, ref_name,
-                          _iter=True))
-            if len(remote_refs) == 0:
-                # Reference is not qualified
-                if self.tag_exists(ref_name):
-                    # We don't know what this ref is in remote, but here it is a tag
-                    ref_name = "refs/tags/%s" % ref_name
-                else:
-                    # In any other case, we assume it is a branch
-                    ref_name = "refs/heads/%s" % ref_name
+            # In any other case, we assume it is a branch
+            ref_name = "refs/heads/%s" % ref_name
             refspec = "%s:%s" % (rev, ref_name)
 
-        self._git("push", dest, refspec, f=force)
+        all_tags_option = '--tags'
+        all_notes_refspec = 'refs/notes/*'
+
+        self._git("push", dest, refspec, all_tags_option, all_notes_refspec,
+                  f=force)
         return self.tip()
 
     def push_notes(self, dest):

--- a/repoman/git/repository.py
+++ b/repoman/git/repository.py
@@ -360,6 +360,9 @@ class Repository(BaseRepo):
         self._git("push", dest, refspec, f=force)
         return self.tip()
 
+    def push_notes(self, dest):
+        self._git("push", dest, "refs/notes/*")
+
     def _merge(self, local_branch=None, other_rev=None,
                other_branch_name=None, dry_run=False, strategy=GitMerge):
         merge = strategy(self, local_branch, other_rev, other_branch_name)
@@ -534,6 +537,7 @@ class Repository(BaseRepo):
             revision = 'HEAD'
         args = ['notes', 'append', '-m', note, revision]
         self._git(*args)
+        return self._git('notes', 'list', revision)
 
     def get_changeset_notes(self, revision=None):
         """Inherited method

--- a/tests/test_gitrepository.py
+++ b/tests/test_gitrepository.py
@@ -445,6 +445,25 @@ class TestGitRepository(unittest.TestCase):
         changesets2 = list(git2('log', 'unqualified', '--', pretty='oneline', _iter=True))
         self.assertEquals(changesets1, changesets2)
 
+    def test_push_only_notes(self):
+        git1 = GitCmd(self.main_repo_bare)
+        git2 = GitCmd(self.cloned_from_repo)
+
+        repo2 = Repository(self.cloned_from_repo)
+        cs = repo2.commit('A commit', allow_empty=True)
+
+        repo2.push(self.main_repo, self.main_repo_bare, rev=cs.hash, ref_name='master')
+
+        notes_ref = repo2.append_note('some note dude', cs.hash)
+        repo2.push(self.main_repo, self.main_repo_bare, ref_name='refs/notes/*')
+
+        notes_ref_repo1, commit_ref_repo1 = git1('notes', 'list').split()
+        notes_ref_repo2, commit_ref_repo2 = git2('notes', 'list').split()
+
+        self.assertEqual(commit_ref_repo1, commit_ref_repo2)
+        self.assertEqual(notes_ref_repo1, notes_ref_repo2)
+        self.assertEqual(notes_ref, notes_ref_repo1)
+
     def test_get_branch(self):
         repo = Repository(self.cloned_from_repo)
         branch = repo.get_branch('newbranch')

--- a/tests/test_gitrepository.py
+++ b/tests/test_gitrepository.py
@@ -399,15 +399,17 @@ class TestGitRepository(unittest.TestCase):
         changesets2 = list(git2('log', 'unqualified', pretty='oneline', _iter=True))
         self.assertEquals(changesets1, changesets2)
 
-    def test_push_notes(self):
+    def test_push_all_with_no_reference(self):
         git1 = GitCmd(self.main_repo_bare)
         git2 = GitCmd(self.cloned_from_repo)
 
         repo2 = Repository(self.cloned_from_repo)
-        cs = repo2.commit('A commit', allow_empty=True)
+        repo2.commit('A commit', allow_empty=True)
+        cs = repo2.commit('A second commit', allow_empty=True)
+        repo2.tag('unqualified', revision=cs.hash)
         notes_ref = repo2.append_note('some note dude', cs.hash)
 
-        repo2.push_notes(self.main_repo_bare)
+        repo2.push(self.main_repo, self.main_repo_bare)
 
         notes_ref_repo1, commit_ref_repo1 = git1('notes', 'list').split()
         notes_ref_repo2, commit_ref_repo2 = git2('notes', 'list').split()
@@ -415,6 +417,33 @@ class TestGitRepository(unittest.TestCase):
         self.assertEqual(commit_ref_repo1, commit_ref_repo2)
         self.assertEqual(notes_ref_repo1, notes_ref_repo2)
         self.assertEqual(notes_ref, notes_ref_repo1)
+
+        changesets1 = list(git1('log', 'unqualified', '--', pretty='oneline', _iter=True))
+        changesets2 = list(git2('log', 'unqualified', '--', pretty='oneline', _iter=True))
+        self.assertEquals(changesets1, changesets2)
+
+    def test_push_all_with_reference_and_revision(self):
+        git1 = GitCmd(self.main_repo_bare)
+        git2 = GitCmd(self.cloned_from_repo)
+
+        repo2 = Repository(self.cloned_from_repo)
+        repo2.commit('A commit', allow_empty=True)
+        cs = repo2.commit('A second commit', allow_empty=True)
+        repo2.tag('unqualified', revision=cs.hash)
+        notes_ref = repo2.append_note('some note dude', cs.hash)
+
+        repo2.push(self.main_repo, self.main_repo_bare, rev=cs.hash, ref_name='master')
+
+        notes_ref_repo1, commit_ref_repo1 = git1('notes', 'list').split()
+        notes_ref_repo2, commit_ref_repo2 = git2('notes', 'list').split()
+
+        self.assertEqual(commit_ref_repo1, commit_ref_repo2)
+        self.assertEqual(notes_ref_repo1, notes_ref_repo2)
+        self.assertEqual(notes_ref, notes_ref_repo1)
+
+        changesets1 = list(git1('log', 'unqualified', '--', pretty='oneline', _iter=True))
+        changesets2 = list(git2('log', 'unqualified', '--', pretty='oneline', _iter=True))
+        self.assertEquals(changesets1, changesets2)
 
     def test_get_branch(self):
         repo = Repository(self.cloned_from_repo)

--- a/tests/test_gitrepository.py
+++ b/tests/test_gitrepository.py
@@ -399,6 +399,23 @@ class TestGitRepository(unittest.TestCase):
         changesets2 = list(git2('log', 'unqualified', pretty='oneline', _iter=True))
         self.assertEquals(changesets1, changesets2)
 
+    def test_push_notes(self):
+        git1 = GitCmd(self.main_repo_bare)
+        git2 = GitCmd(self.cloned_from_repo)
+
+        repo2 = Repository(self.cloned_from_repo)
+        cs = repo2.commit('A commit', allow_empty=True)
+        notes_ref = repo2.append_note('some note dude', cs.hash)
+
+        repo2.push_notes(self.main_repo_bare)
+
+        notes_ref_repo1, commit_ref_repo1 = git1('notes', 'list').split()
+        notes_ref_repo2, commit_ref_repo2 = git2('notes', 'list').split()
+
+        self.assertEqual(commit_ref_repo1, commit_ref_repo2)
+        self.assertEqual(notes_ref_repo1, notes_ref_repo2)
+        self.assertEqual(notes_ref, notes_ref_repo1)
+
     def test_get_branch(self):
         repo = Repository(self.cloned_from_repo)
         branch = repo.get_branch('newbranch')


### PR DESCRIPTION
I know we talked about extending the current `push` function, but I don't really like how is done now. Too implicit and no solution conviced me to do so. I've created a stand-alone `push_notes`.

BTW I've checked that cloning with `--mirror` fetches the notes automatically.