### PR TITLE
Add exception in case of git fetch fails

### DIFF
--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -71,7 +71,7 @@ class DepotOperations(BaseDepotOps):
             logger.exception(
                 'Error fetching from url %s (%s): %s\nComplete output: %s',
                 url, git_path, e, e.stdout)
-            return False
+            raise
 
         logger.debug("Output:\n%s" % output)
         if sh.git('rev-parse', '--is-bare-repository', _cwd=path).strip() == 'false':

--- a/repoman/git/depot_operations.py
+++ b/repoman/git/depot_operations.py
@@ -61,11 +61,18 @@ class DepotOperations(BaseDepotOps):
             path,
             sh.git('rev-parse', '--git-dir', _cwd=path).strip())
         logger.debug("Executing git -c core.bare=true fetch " + url + " +refs/*:refs/* on " + git_path)
-        output = sh.git('-c', 'core.bare=true', 'fetch',
-                        url,
-                        '+refs/*:refs/*',
-                        _cwd=git_path,
-                        _err_to_out=True)
+        try:
+            output = sh.git('-c', 'core.bare=true', 'fetch',
+                            url,
+                            '+refs/*:refs/*',
+                            _cwd=git_path,
+                            _err_to_out=True)
+        except sh.ErrorReturnCode as e:
+            logger.exception(
+                'Error fetching from url %s (%s): %s\nComplete output: %s',
+                url, git_path, e, e.stdout)
+            return False
+
         logger.debug("Output:\n%s" % output)
         if sh.git('rev-parse', '--is-bare-repository', _cwd=path).strip() == 'false':
             self._clear_working_copy(path)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 # testing
-pytest
+pytest>=3.6
 pytest-cov
 mox3
 unittest2

--- a/tests/test_gitdepotoperations.py
+++ b/tests/test_gitdepotoperations.py
@@ -224,6 +224,32 @@ class TestGitDepotOperations(unittest.TestCase):
         self.assertTrue(workspace1.request_refresh({
             os.path.join(self.environment_path, 'remote'): ['my-branch1']}))
 
+    def test_request_refresh_git_url_does_not_exist(self):
+        dcvs = DepotOperations()
+
+        # Remote repository
+        self.add_content_to_repo(
+            os.path.join(FIXTURE_PATH, 'fixture-2.git.bundle'),
+            'remote')
+
+        # Master cache
+        master = dcvs.init_depot(
+            os.path.join(self.environment_path, 'master'),
+            parent=None,
+            source=os.path.join(self.environment_path, 'other-remote'))
+
+        # Workspace depot
+        workspace1 = dcvs.init_depot(
+            os.path.join(self.environment_path, 'workspace1'),
+            parent=master,
+            source=os.path.join(self.environment_path, 'master'))
+
+        self.assertFalse(workspace1.request_refresh(
+            {
+                os.path.join(self.environment_path, 'other-remote'): ['master']
+            }
+        ))
+
     def _test_request_refresh(self, f):
         dcvs = DepotOperations()
 

--- a/tests/test_gitdepotoperations.py
+++ b/tests/test_gitdepotoperations.py
@@ -244,11 +244,13 @@ class TestGitDepotOperations(unittest.TestCase):
             parent=master,
             source=os.path.join(self.environment_path, 'master'))
 
-        self.assertFalse(workspace1.request_refresh(
+        self.assertRaises(
+            sh.ErrorReturnCode,
+            workspace1.request_refresh,
             {
                 os.path.join(self.environment_path, 'other-remote'): ['master']
             }
-        ))
+        )
 
     def _test_request_refresh(self, f):
         dcvs = DepotOperations()


### PR DESCRIPTION
This PR adds exception management in case of `git fetch` command fails in `grab_changesets` functions.
Following the approach of the other flows in this function, in case of error it should return a False.

The functions calling `grab_changesets` should take care of checking the returned value.

This PR also includes a test for this scenario.