### PR TITLE
Add support for python 3.7 and solve DeprecationWarnings

### DIFF
--- a/repoman/hg/repository.py
+++ b/repoman/hg/repository.py
@@ -636,7 +636,7 @@ class Repository(BaseRepo):
         """
         Converts an indexer changeset to an Changeset
         """
-        fixed_date = re.match("(.*)[\+|\-]",
+        fixed_date = re.match(r"(.*)[\+|\-]",
                               indexer_changeset.date).groups(0)[0]
         # The date format provided by fecru is: 2013-05-09T15:11:44+02:00
         cs_datetime = datetime.datetime.strptime(

--- a/repoman/roster.py
+++ b/repoman/roster.py
@@ -154,7 +154,7 @@ class Roster(collections.abc.MutableMapping):
             while True:
                 row = cursor.fetchone()
                 if row is None:
-                    raise StopIteration()
+                    return
                 yield row[0]
 
     def __len__(self):

--- a/repoman/roster.py
+++ b/repoman/roster.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-import collections
+import collections.abc
 import sqlite3
 import time
 
@@ -80,7 +80,7 @@ def unmarshall(db_str):
     return Clone(path, status, task, task_name, timestamp)
 
 
-class Roster(collections.MutableMapping):
+class Roster(collections.abc.MutableMapping):
     """Manages the file used as a roster. Provides dict API to it."""
 
     class DBCursor(object):

--- a/tests/test_changeset_git.py
+++ b/tests/test_changeset_git.py
@@ -56,14 +56,14 @@ class TestGitChangeset(unittest.TestCase):
         git = GitCmd(os.path.join(self.environment_path, 'remote'))
         gitrepo = Repository(os.path.join(self.environment_path, 'remote'))
         gitcs = gitrepo[git('rev-parse', 'HEAD')]
-        self.assertEquals(gitcs.author, "Jose Plana")
-        self.assertEquals(
+        self.assertEqual(gitcs.author, "Jose Plana")
+        self.assertEqual(
             gitcs.hash, "52109e71fd7f16cb366acfcbb140d6d7f2fc50c9")
-        self.assertEquals(
+        self.assertEqual(
             gitcs.desc.rstrip('\n'), "Second changeset".rstrip('\n'))
         self.assertFalse(gitcs.merge)
         print(gitrepo.get_parents("52109e71fd7f16cb366acfcbb140d6d7f2fc50c9"))
-        self.assertEquals(
+        self.assertEqual(
             gitcs.parents[0].hash, "e3b1fc907ea8b3482e29eb91520c0e2eee2b4cdb")
 
     def test_create_branch(self):
@@ -77,14 +77,14 @@ class TestGitChangeset(unittest.TestCase):
         gitrepo = Repository(non_bare_repo_path)
         gitcs = gitrepo[git('rev-parse', 'HEAD')]
         branch = gitcs.create_branch('fakebranch')
-        self.assertEquals(branch.get_changeset(), gitrepo.tip())
-        self.assertEquals(
+        self.assertEqual(branch.get_changeset(), gitrepo.tip())
+        self.assertEqual(
             'fakebranch', git('rev-parse', '--abbrev-ref', 'fakebranch'))
 
     def test___str__(self):
         git = GitCmd(os.path.join(self.environment_path, 'remote'))
         gitrepo = Repository(os.path.join(self.environment_path, 'remote'))
         gitcs = gitrepo[git('rev-parse', 'HEAD')]
-        self.assertEquals(
+        self.assertEqual(
             gitcs.__str__(),
             git('rev-parse', 'HEAD')[:Changeset.SHORT_HASH_COUNT])

--- a/tests/test_clonemanager.py
+++ b/tests/test_clonemanager.py
@@ -48,19 +48,19 @@ class AbstractTestDepotManager(object):
         new_clone = self.rman.give_me_depot(
             '1', 'bla', {}, self.rman.main_cache_path)
         self.assertIsNotNone(new_clone)
-        self.assertEquals(Clone.INUSE, self.rman.roster[new_clone.path].status)
+        self.assertEqual(Clone.INUSE, self.rman.roster[new_clone.path].status)
 
     def test_free_depot(self):
         # Reserve clone
         repo = self.rman.give_me_depot(
             '1', 'bla', {}, self.rman.main_cache_path)
         self.assertIsNotNone(repo)
-        self.assertEquals(Clone.INUSE, self.rman.roster[repo.path].status)
+        self.assertEqual(Clone.INUSE, self.rman.roster[repo.path].status)
 
         # Free the repo.
         self.rman.free_depot(repo, '1')
         self.assertIn(repo.path, self.rman.roster)
-        self.assertEquals(Clone.FREE, self.rman.roster[repo.path].status)
+        self.assertEqual(Clone.FREE, self.rman.roster[repo.path].status)
 
     @staticmethod
     def _add_file(repo, file_name):
@@ -155,7 +155,7 @@ class AbstractTestDepotManager(object):
         ][0]
 
         self.assertSequenceEqual([repo_clon], self.rman.roster.get_available())
-        self.assertEquals(
+        self.assertEqual(
             repo_clon, self.rman.get_available_clone(repo_clon.path))
         self.assertIsNone(self.rman.get_not_available_clone(repo_clon.path))
 

--- a/tests/test_commitmessage.py
+++ b/tests/test_commitmessage.py
@@ -28,7 +28,7 @@ class TestCommitMessage(unittest.TestCase):
         message = "A message with %(something)s"
         values = {'something': 'foo'}
         commit_message = CommitMessage(message, values)
-        self.assertEquals(str(commit_message), message % values)
+        self.assertEqual(str(commit_message), message % values)
 
     def testCloseBranchMessage(self):
         builder = DefaultCommitMessageBuilder()

--- a/tests/test_depot.py
+++ b/tests/test_depot.py
@@ -80,7 +80,7 @@ class TestDepot(unittest.TestCase):
             'b': range(8, 13),
         }
 
-        self.assertEquals(
+        self.assertEqual(
             {'a': range(1, 6), 'b': [8]},
             self.depot._filter_missing_changesets(reqs))
 

--- a/tests/test_gitdepotoperations.py
+++ b/tests/test_gitdepotoperations.py
@@ -102,21 +102,21 @@ class TestGitDepotOperations(unittest.TestCase):
         dcvs = DepotOperations()
 
         # It is there
-        self.assertEquals(
+        self.assertEqual(
             [],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
                 ['52109e71fd7f16cb366acfcbb140d6d7f2fc50c9']))
 
         # It is not there
-        self.assertEquals(
+        self.assertEqual(
             [missing_changeset],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
                 [missing_changeset]))
 
         # Missing branches and changesets
-        self.assertEquals(
+        self.assertEqual(
             ['missing_branch', missing_changeset, 'deadbeef'],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
@@ -124,7 +124,7 @@ class TestGitDepotOperations(unittest.TestCase):
 
 
         # Multiple changesets
-        self.assertEquals(
+        self.assertEqual(
             [missing_changeset],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
@@ -132,7 +132,7 @@ class TestGitDepotOperations(unittest.TestCase):
                  '52109e71fd7f16cb366acfcbb140d6d7f2fc50c9']))
 
         # All changesets
-        self.assertEquals(
+        self.assertEqual(
             [],
             dcvs.check_changeset_availability(
                 os.path.join(self.environment_path, 'repo1'),
@@ -166,7 +166,7 @@ class TestGitDepotOperations(unittest.TestCase):
         # check that we are not mixing files with changesets when checking
         # available changesets in working copies
         open(os.path.join(workspace1.path, 'deadbeef'), 'w').close()
-        self.assertEquals(
+        self.assertEqual(
             ['deadbeef'],
             dcvs.check_changeset_availability(workspace1.path, ['deadbeef']))
 
@@ -183,7 +183,7 @@ class TestGitDepotOperations(unittest.TestCase):
             source=os.path.join(self.environment_path, 'remote'))
 
         # Changeset both there
-        self.assertEquals(
+        self.assertEqual(
             True, dcvs.grab_changesets(
                 os.path.join(self.environment_path, 'master'),
                 os.path.join(self.environment_path, 'remote'),
@@ -288,7 +288,7 @@ class TestGitDepotOperations(unittest.TestCase):
         self.assertTrue(workspace1.request_refresh({
             os.path.join(self.environment_path, 'other'): ['newbranch']}))
 
-        self.assertEquals(
+        self.assertEqual(
             sh.git('rev-parse', 'newbranch', _cwd=workspace1.path).strip(),
             "a277468c9cc0088ba69e0a4b085822d067e360ff")
 

--- a/tests/test_gitrepository.py
+++ b/tests/test_gitrepository.py
@@ -121,7 +121,7 @@ class TestGitRepository(unittest.TestCase):
         ancestor = gitrepo.get_ancestor(gitrepo[headmaster],
                                         gitrepo[headnewbranch])
 
-        self.assertEquals(ancestor.hash, ancestor_hash)
+        self.assertEqual(ancestor.hash, ancestor_hash)
 
         with self.assertRaises(RepositoryError):
             gitrepo.get_ancestor(None, ancestor_hash)
@@ -155,15 +155,15 @@ class TestGitRepository(unittest.TestCase):
         status = get_status()
         self.assertTrue(file_name in status)
         self.assertTrue(file_name2 in status)
-        self.assertEquals(status[file_name], '??')
-        self.assertEquals(status[file_name2], '??')
+        self.assertEqual(status[file_name], '??')
+        self.assertEqual(status[file_name2], '??')
 
         gitrepo = Repository(self.main_repo)
         gitrepo.add([file_name, file_name2])
 
         status = get_status()
-        self.assertEquals(status[file_name], 'A')
-        self.assertEquals(status[file_name2], 'A')
+        self.assertEqual(status[file_name], 'A')
+        self.assertEqual(status[file_name2], 'A')
         with self.assertRaises(RepositoryError):
             gitrepo.add("nonexistentfile")
 
@@ -183,9 +183,9 @@ class TestGitRepository(unittest.TestCase):
 
         final_len = len(list(git('log', 'HEAD', pretty='oneline', _iter=True)))
 
-        self.assertEquals(final_len, initial_len + 1)
-        self.assertEquals(git('log', '-1', pretty='%B'), commit_msg)
-        self.assertEquals(commit.desc, commit_msg)
+        self.assertEqual(final_len, initial_len + 1)
+        self.assertEqual(git('log', '-1', pretty='%B'), commit_msg)
+        self.assertEqual(commit.desc, commit_msg)
         self.assertIsNone(gitrepo.commit(commit_msg))
 
     def test_commit_commits_all(self):
@@ -207,7 +207,7 @@ class TestGitRepository(unittest.TestCase):
 
         self.assertTrue(os.path.exists(file_path))
         with open(file_path) as fd:
-            self.assertEquals(expected_content, fd.read())
+            self.assertEqual(expected_content, fd.read())
 
     def test_commit_commits_but_with_removed_files(self):
         file_name = "test1.txt"
@@ -231,7 +231,7 @@ class TestGitRepository(unittest.TestCase):
         c2 = gitrepo.commit('Other commit', allow_empty=True)
         gitrepo.commit('Commit with custom parent', allow_empty=True,
             custom_parent=c1.hash)
-        self.assertEquals(
+        self.assertEqual(
             [p.hash for p in gitrepo.parents()],
             [c2.hash, c1.hash])
 
@@ -248,8 +248,8 @@ class TestGitRepository(unittest.TestCase):
         # Checkout to master
         gitrepo.update('master')
         cs = gitrepo.merge(other_rev=gitrepo[headnewbranch])
-        self.assertEquals(len(git('log', '-1', pretty='%P').split()), 2)
-        self.assertEquals(git('rev-parse', 'HEAD'), cs.hash)
+        self.assertEqual(len(git('log', '-1', pretty='%P').split()), 2)
+        self.assertEqual(git('rev-parse', 'HEAD'), cs.hash)
 
     def test_merge_with_conflict(self):
         gitrepo = Repository(self.cloned_from_repo)
@@ -290,9 +290,9 @@ class TestGitRepository(unittest.TestCase):
         gitrepo.update('master')
         cs = gitrepo.merge_fastforward(
             other_rev=ff_head, other_branch_name='test')
-        self.assertEquals(len(git('log', '-1', pretty='%P').split()), 1)
-        self.assertEquals(git('rev-parse', 'HEAD'), cs.hash)
-        self.assertEquals(ff_head.hash, cs.hash)
+        self.assertEqual(len(git('log', '-1', pretty='%P').split()), 1)
+        self.assertEqual(git('rev-parse', 'HEAD'), cs.hash)
+        self.assertEqual(ff_head.hash, cs.hash)
         self.assertTrue(os.path.isfile(ff_file))
 
     def test_merge_fastforward_no_ff(self):
@@ -310,10 +310,10 @@ class TestGitRepository(unittest.TestCase):
         ff_head = gitrepo.commit(message="commit ff file")
         gitrepo.update('master')
         cs = gitrepo.merge(other_rev=ff_head, other_branch_name='test')
-        self.assertEquals(len(git('log', '-1', pretty='%P').split()), 2)
-        self.assertEquals(git('rev-parse', 'HEAD'), cs.hash)
+        self.assertEqual(len(git('log', '-1', pretty='%P').split()), 2)
+        self.assertEqual(git('rev-parse', 'HEAD'), cs.hash)
         # We want a commit in fastforward merges, hashes must be different
-        self.assertNotEquals(ff_head.hash, cs.hash)
+        self.assertNotEqual(ff_head.hash, cs.hash)
         self.assertTrue(os.path.isfile(ff_file))
 
     def test_merge_isuptodate(self):
@@ -329,23 +329,23 @@ class TestGitRepository(unittest.TestCase):
         gitrepo.tag("new-tag", message="fake tag")
 
         git = GitCmd(self.main_repo)
-        self.assertNotEquals(git('show-ref', 'refs/tags/new-tag'), '')
+        self.assertNotEqual(git('show-ref', 'refs/tags/new-tag'), '')
 
     def test_branch(self):
         gitrepo = Repository(self.cloned_from_repo)
         gitrepo.branch("test_branch")
         git = GitCmd(self.cloned_from_repo)
         # Checking we are in the branch
-        self.assertEquals(
+        self.assertEqual(
                 git('rev-parse', 'test_branch'),
                 git('rev-parse', 'HEAD'))
-        self.assertEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'test_branch')
+        self.assertEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'test_branch')
 
         gitrepo.branch('newbranch')
-        self.assertEquals(
+        self.assertEqual(
                 git('rev-parse', 'newbranch'),
                 git('rev-parse', 'HEAD'))
-        self.assertEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'newbranch')
+        self.assertEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'newbranch')
 
     def test_push(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -366,7 +366,7 @@ class TestGitRepository(unittest.TestCase):
 
         changesets1 = list(git1('log', pretty='oneline', _iter=True))
         changesets2 = list(git2('log', pretty='oneline', _iter=True))
-        self.assertEquals(len(changesets1), len(changesets2))
+        self.assertEqual(len(changesets1), len(changesets2))
 
     def test_push_to_unqualified_destination(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -381,7 +381,7 @@ class TestGitRepository(unittest.TestCase):
 
         changesets1 = list(git1('log', 'unqualified', pretty='oneline', _iter=True))
         changesets2 = list(git2('log', cs.hash, pretty='oneline', _iter=True))
-        self.assertEquals(changesets1, changesets2)
+        self.assertEqual(changesets1, changesets2)
 
     def test_push_tag_to_unqualified_destination(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -397,7 +397,7 @@ class TestGitRepository(unittest.TestCase):
 
         changesets1 = list(git1('log', 'unqualified', pretty='oneline', _iter=True))
         changesets2 = list(git2('log', 'unqualified', pretty='oneline', _iter=True))
-        self.assertEquals(changesets1, changesets2)
+        self.assertEqual(changesets1, changesets2)
 
     def test_push_all_with_no_reference(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -420,7 +420,7 @@ class TestGitRepository(unittest.TestCase):
 
         changesets1 = list(git1('log', 'unqualified', '--', pretty='oneline', _iter=True))
         changesets2 = list(git2('log', 'unqualified', '--', pretty='oneline', _iter=True))
-        self.assertEquals(changesets1, changesets2)
+        self.assertEqual(changesets1, changesets2)
 
     def test_push_all_with_reference_and_revision(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -443,7 +443,7 @@ class TestGitRepository(unittest.TestCase):
 
         changesets1 = list(git1('log', 'unqualified', '--', pretty='oneline', _iter=True))
         changesets2 = list(git2('log', 'unqualified', '--', pretty='oneline', _iter=True))
-        self.assertEquals(changesets1, changesets2)
+        self.assertEqual(changesets1, changesets2)
 
     def test_push_only_notes(self):
         git1 = GitCmd(self.main_repo_bare)
@@ -467,10 +467,10 @@ class TestGitRepository(unittest.TestCase):
     def test_get_branch(self):
         repo = Repository(self.cloned_from_repo)
         branch = repo.get_branch('newbranch')
-        self.assertEquals(branch.name, 'newbranch')
+        self.assertEqual(branch.name, 'newbranch')
         repo.update('newbranch')
         branch = repo.get_branch()
-        self.assertEquals(branch.name, 'newbranch')
+        self.assertEqual(branch.name, 'newbranch')
         with self.assertRaises(RepositoryError):
             branch = repo.get_branch('does_not_exist')
 
@@ -481,73 +481,73 @@ class TestGitRepository(unittest.TestCase):
         # Just cs_from
         just_from_second = gitrepo.get_revset(
             cs_from="52109e71fd7f16cb366acfcbb140d6d7f2fc50c9")
-        self.assertEquals(len(list(just_from_second)), 3)
+        self.assertEqual(len(list(just_from_second)), 3)
 
         # No params
         no_params = gitrepo.get_revset()
-        self.assertEquals(len(list(no_params)), 4)
+        self.assertEqual(len(list(no_params)), 4)
 
         # From first commit to head
         first_to_head = gitrepo.get_revset(
             cs_from="e3b1fc907ea8b3482e29eb91520c0e2eee2b4cdb",
             cs_to=git('rev-parse', 'HEAD'))
-        self.assertEquals(len(list(first_to_head)), 4)
+        self.assertEqual(len(list(first_to_head)), 4)
         second_to_head = gitrepo.get_revset(
             cs_from="52109e71fd7f16cb366acfcbb140d6d7f2fc50c9",
             cs_to=git('rev-parse', 'HEAD'))
-        self.assertEquals(len(list(second_to_head)), 3)
+        self.assertEqual(len(list(second_to_head)), 3)
         second_to_third = gitrepo.get_revset(
             cs_from="52109e71fd7f16cb366acfcbb140d6d7f2fc50c9",
             cs_to="2a9e1b9be3fb95ed0841aacc1f20972430dc1a5c")
-        self.assertEquals(len(list(second_to_third)), 2)
+        self.assertEqual(len(list(second_to_third)), 2)
 
         # Just by branch
         by_branch = gitrepo.get_revset(branch='newbranch')
-        self.assertEquals(len(list(by_branch)), 3)
+        self.assertEqual(len(list(by_branch)), 3)
 
         # Just by branch being in another
         gitrepo.update('master')
         by_branch = gitrepo.get_revset(branch='newbranch')
-        self.assertEquals(len(list(by_branch)), 3)
-        self.assertEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'master')
+        self.assertEqual(len(list(by_branch)), 3)
+        self.assertEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'master')
 
         # Only common ancestor belong to newbranch
         common_ancestor = gitrepo.get_revset(
             cs_to="b7fa61d5faf434642e35744b55d8d8f367afc343",
             cs_from="52109e71fd7f16cb366acfcbb140d6d7f2fc50c9",
             branch='newbranch')
-        self.assertEquals(len(list(common_ancestor)), 1)
+        self.assertEqual(len(list(common_ancestor)), 1)
 
         # Zero changesets belong to newbranch
         none = gitrepo.get_revset(
             cs_to="b7fa61d5faf434642e35744b55d8d8f367afc343",
             cs_from="2a9e1b9be3fb95ed0841aacc1f20972430dc1a5c",
             branch='newbranch')
-        self.assertEquals(len(list(none)), 0)
+        self.assertEqual(len(list(none)), 0)
 
         # From the beginning to master tip so only common changesets in both
         # branches
         common_changesets = gitrepo.get_revset(
             cs_to="b7fa61d5faf434642e35744b55d8d8f367afc343",
             branch='newbranch')
-        self.assertEquals(len(list(common_changesets)), 2)
+        self.assertEqual(len(list(common_changesets)), 2)
 
         # From the beginning to common ancestor, that belongs to both branches
         toboth = gitrepo.get_revset(
             cs_to="52109e71fd7f16cb366acfcbb140d6d7f2fc50c9",
             branch='newbranch')
-        self.assertEquals(len(list(toboth)), 2)
+        self.assertEqual(len(list(toboth)), 2)
 
         # From newbranch origin to newbranch tip
         ignore_branch3 = gitrepo.get_revset(
             cs_from="e3b1fc907ea8b3482e29eb91520c0e2eee2b4cdb",
             branch='newbranch')
-        self.assertEquals(len(list(ignore_branch3)), 3)
+        self.assertEqual(len(list(ignore_branch3)), 3)
 
     def test_get_branch_tip(self):
         git = GitCmd(self.cloned_from_repo)
         gitrepo = Repository(self.cloned_from_repo)
-        self.assertEquals(
+        self.assertEqual(
             gitrepo.get_branch_tip('master').hash, git('rev-parse', 'master'))
 
     def test_update(self):
@@ -563,25 +563,25 @@ class TestGitRepository(unittest.TestCase):
         self.assertFalse(os.path.isfile(os.path.join(path, 'file2.txt')))
         self.assertTrue(os.path.isfile(os.path.join(path, 'file1.txt')))
         self.assertFalse(os.path.isfile(os.path.join(path, 'file3.txt')))
-        self.assertNotEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
+        self.assertNotEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
 
         gitrepo.update("branch-1")
         self.assertTrue(os.path.isfile(os.path.join(path, 'file2.txt')))
         self.assertTrue(os.path.isfile(os.path.join(path, 'file1.txt')))
         self.assertFalse(os.path.isfile(os.path.join(path, 'file3.txt')))
-        self.assertNotEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
+        self.assertNotEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
 
         gitrepo.update("branch-2")
         self.assertTrue(os.path.isfile(os.path.join(path, 'file3.txt')))
         self.assertFalse(os.path.isfile(os.path.join(path, 'file2.txt')))
         self.assertTrue(os.path.isfile(os.path.join(path, 'file1.txt')))
-        self.assertNotEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
+        self.assertNotEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
 
         gitrepo.update("08b952ae66e59b216b1171c0c57082353bc80863")
         self.assertFalse(os.path.isfile(os.path.join(path, 'file3.txt')))
         self.assertFalse(os.path.isfile(os.path.join(path, 'file2.txt')))
         self.assertTrue(os.path.isfile(os.path.join(path, 'file1.txt')))
-        self.assertEquals(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
+        self.assertEqual(git('rev-parse', '--abbrev-ref', 'HEAD'), 'HEAD')
 
     def test_update_failures(self):
         repo_name = 'fixture-3'
@@ -596,7 +596,7 @@ class TestGitRepository(unittest.TestCase):
     def test_parents(self):
         git = GitCmd(self.cloned_from_repo)
         gitrepo = Repository(self.cloned_from_repo)
-        self.assertEquals([x.hash for x in gitrepo.parents()],
+        self.assertEqual([x.hash for x in gitrepo.parents()],
                           git('log', '-1', pretty='%P').split())
 
     def test_strip(self):
@@ -606,8 +606,8 @@ class TestGitRepository(unittest.TestCase):
         parent_old_head = git('log', '-1', pretty='%P').split()[0]
         gitrepo.strip(gitrepo[old_head])
         new_head = git('rev-parse', 'HEAD')
-        self.assertNotEquals(old_head, new_head)
-        self.assertEquals(new_head, parent_old_head)
+        self.assertNotEqual(old_head, new_head)
+        self.assertEqual(new_head, parent_old_head)
 
     def test_is_merge(self):
         git = GitCmd(self.cloned_from_repo)
@@ -633,12 +633,12 @@ class TestGitRepository(unittest.TestCase):
         masterhead_hash = 'b7fa61d5faf434642e35744b55d8d8f367afc343'
         newbranch_hash = 'a277468c9cc0088ba69e0a4b085822d067e360ff'
         firstway = gitrepo.compare_branches(masterhead_hash, 'newbranch')
-        self.assertEquals([
+        self.assertEqual([
             gitrepo['b7fa61d5faf434642e35744b55d8d8f367afc343'],
             gitrepo['2a9e1b9be3fb95ed0841aacc1f20972430dc1a5c']],
             firstway)
         secondway = gitrepo.compare_branches(newbranch_hash, 'master')
-        self.assertEquals([
+        self.assertEqual([
             gitrepo['a277468c9cc0088ba69e0a4b085822d067e360ff']],
             secondway)
 
@@ -651,13 +651,13 @@ class TestGitRepository(unittest.TestCase):
         # remotely too
         gitrepo.push(None, self.main_repo, ref_name=branch_name)
 
-        self.assertEquals(len(list(gitrepo.get_branches())), 2)
-        self.assertEquals(len(list(gitrepo_main.get_branches())), 4)
+        self.assertEqual(len(list(gitrepo.get_branches())), 2)
+        self.assertEqual(len(list(gitrepo_main.get_branches())), 4)
 
         gitrepo.terminate_branch(branch_name, None, self.main_repo)
 
-        self.assertEquals(len(list(gitrepo.get_branches())), 1)
-        self.assertEquals(len(list(gitrepo_main.get_branches())), 4)
+        self.assertEqual(len(list(gitrepo.get_branches())), 1)
+        self.assertEqual(len(list(gitrepo_main.get_branches())), 4)
 
         # Terminating a branch already terminated
         # it shouldn't do anything but warning with a message
@@ -672,13 +672,13 @@ class TestGitRepository(unittest.TestCase):
         # remotely too
         gitrepo.push(None, self.main_repo, ref_name=branch_name)
 
-        self.assertEquals(len(list(gitrepo.get_branches())), 2)
-        self.assertEquals(len(list(gitrepo_main.get_branches())), 4)
+        self.assertEqual(len(list(gitrepo.get_branches())), 2)
+        self.assertEqual(len(list(gitrepo_main.get_branches())), 4)
 
         gitrepo.exterminate_branch(branch_name, None, self.main_repo)
 
-        self.assertEquals(len(list(gitrepo.get_branches())), 1)
-        self.assertEquals(len(list(gitrepo_main.get_branches())), 3)
+        self.assertEqual(len(list(gitrepo.get_branches())), 1)
+        self.assertEqual(len(list(gitrepo_main.get_branches())), 3)
 
         # Terminating a branch already terminated
         # it shouldn't do anything but warning with a message

--- a/tests/test_repo_indexer.py
+++ b/tests/test_repo_indexer.py
@@ -56,7 +56,7 @@ class TestRepoIndexer(unittest.TestCase):
         res = repo_indexer._indexers
         ordered_keys = iter([1, 10, 13])
         for i in res.items():
-            self.assertEquals(i[0], ordered_keys.__next__())
+            self.assertEqual(i[0], ordered_keys.__next__())
 
     def test_get_branches_first_bad_second_good(self):
         expected = ['a', 'b']
@@ -78,6 +78,6 @@ class TestRepoIndexer(unittest.TestCase):
 
         res = repo_indexer.get_branches(limit=2)
 
-        self.assertEquals(res, expected)
+        self.assertEqual(res, expected)
 
         self.mox.VerifyAll()

--- a/tests/test_roster.py
+++ b/tests/test_roster.py
@@ -50,7 +50,7 @@ class TestRoster(unittest.TestCase):
         self.roster['/test1'] = clone_mother(status=Clone.INUSE)
         self.roster['/test2'] = clone_mother(status=Clone.INUSE)
         self.roster.clear()
-        self.assertEquals(0, len(self.roster))
+        self.assertEqual(0, len(self.roster))
 
     def test_missing(self):
         self.assertRaises(KeyError, lambda x: self.roster[x], '/test')
@@ -68,12 +68,12 @@ class TestRoster(unittest.TestCase):
         self.roster['/test1'] = r1
         self.roster['/test2'] = r2
         r2.status = Clone.INUSE
-        self.assertEquals(r2, self.roster.reserve_clone('1', 'test'))
+        self.assertEqual(r2, self.roster.reserve_clone('1', 'test'))
 
     def test_clone_str(self):
         r1 = clone_mother(status=Clone.INUSE)
-        self.assertEquals(r1.__str__(), str(r1.__dict__))
-        self.assertEquals(r1.__repr__(), str(r1.__dict__))
+        self.assertEqual(r1.__str__(), str(r1.__dict__))
+        self.assertEqual(r1.__repr__(), str(r1.__dict__))
 
     def test_free_clone(self):
         r1 = clone_mother(status=Clone.INUSE, task='1')
@@ -85,7 +85,7 @@ class TestRoster(unittest.TestCase):
         self.roster['/test3'] = r3
         self.roster.free_clone(r1, '1')
         r1 = self.roster['/test1']
-        self.assertEquals(Clone.FREE, r1.status)
+        self.assertEqual(Clone.FREE, r1.status)
         # Check cannot remove elements from the roster not owned.
         self.assertRaises(RosterError, self.roster.free_clone, r3, 1)
 
@@ -136,9 +136,9 @@ class TestRoster(unittest.TestCase):
     def test_get_single(self):
         self.assertListEqual([], self.roster.get_available())
         r1 = self.roster.add('/test1', u'1', 'test')
-        self.assertEquals(r1, self.roster['/test1'])
+        self.assertEqual(r1, self.roster['/test1'])
         r2 = self.roster.add('/test2', u'1', 'test')
-        self.assertEquals(r2, self.roster['/test2'])
+        self.assertEqual(r2, self.roster['/test2'])
 
     def test_add_limit(self):
         # tests the limit imposed to the creation of clones

--- a/tests/test_signature.py
+++ b/tests/test_signature.py
@@ -28,7 +28,7 @@ class DummyRepository(Repository):
         self.expected_signature = None
 
     def tag(self, *args, **kwargs):
-        self.test_case.assertEquals(self.signature, self.expected_signature)
+        self.test_case.assertEqual(self.signature, self.expected_signature)
 
 
 class TestSignature(unittest.TestCase):
@@ -42,8 +42,8 @@ class TestSignature(unittest.TestCase):
     def testOnlyUser(self):
         a_user = 'foouser'
         signature = Signature(user=a_user)
-        self.assertEquals(signature.user, a_user)
-        self.assertEquals(signature.author, a_user)
+        self.assertEqual(signature.user, a_user)
+        self.assertEqual(signature.author, a_user)
         self.assertTrue(a_user in str(signature))
         self.assertTrue(a_user in signature.email)
         self.assertTrue(a_user in signature.author_email)
@@ -58,17 +58,17 @@ class TestSignature(unittest.TestCase):
             email=a_user_email,
             author=an_author,
             author_email=an_author_email)
-        self.assertEquals(signature.user, a_user)
-        self.assertEquals(signature.email, a_user_email)
-        self.assertEquals(signature.author, an_author)
-        self.assertEquals(signature.author_email, an_author_email)
+        self.assertEqual(signature.user, a_user)
+        self.assertEqual(signature.email, a_user_email)
+        self.assertEqual(signature.author, an_author)
+        self.assertEqual(signature.author_email, an_author_email)
         self.assertTrue(a_user in str(signature))
         self.assertTrue(a_user_email in str(signature))
 
     def testRepositorySignature(self):
         a_signature = Signature()
         repository = DummyRepository(self, signature=a_signature)
-        self.assertEquals(repository.signature, a_signature)
+        self.assertEqual(repository.signature, a_signature)
         repository.expected_signature = a_signature
         repository.tag('foo')
 


### PR DESCRIPTION
With this Pull requests, I wanted to add support of python 3.7:
- removing some deprecation warnings
```
/src/repoman-scm/repoman/hg/repository.py:639
  /src/repoman-scm/repoman/hg/repository.py:639: DeprecationWarning: invalid escape sequence \+
    fixed_date = re.match("(.*)[\+|\-]",
```
```
/src/repoman-scm/repoman/roster.py:83
  /src/repoman-scm/repoman/roster.py:83: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class Roster(collections.MutableMapping):
```
- Removed more DeprecationWarnings about assertEquals and assertNotEquals.
- Due to this [PEP-0479](https://www.python.org/dev/peps/pep-0479/), generators change how they behave against StopIteration exception.

Still some warnings dependent on the library used for testing (mox) :(
```/usr/local/lib/python3.7/dist-packages/unittest2/compatibility.py:143
  /usr/local/lib/python3.7/dist-packages/unittest2/compatibility.py:143: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working
    class ChainMap(collections.MutableMapping):

tests/test_depot.py: 16 tests with warnings
tests/test_repo_indexer.py: 4 tests with warnings
  /usr/local/lib/python3.7/dist-packages/mox3/mox.py:909: DeprecationWarning: inspect.getargspec() is deprecated since Python 3.0, use inspect.signature() or inspect.getfullargspec()
    self._args, varargs, varkw, defaults = inspect.getargspec(method)

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

**Tested with** python 3.4.2 , 3.5.3 and 3.7.3